### PR TITLE
Add derived image builds, kicking off with rust-latest

### DIFF
--- a/base/build.sh
+++ b/base/build.sh
@@ -2,6 +2,11 @@
 
 set -eux
 
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+BASE_DIR="$REPO_ROOT/base"
+
+pushd $BASE_DIR
+
 source definitions.sh
 
 for debrel in ${DEBIAN_RELEASES[@]}; do
@@ -12,5 +17,11 @@ for debrel in ${DEBIAN_RELEASES[@]}; do
         --build-arg DEBIAN_RELEASE="$debrel" \
         .
 done
+
+for derived_build in $(find derived -name "build.sh"); do
+    ./$derived_build
+done
+
+popd
 
 echo "Done!"

--- a/base/derived/README.md
+++ b/base/derived/README.md
@@ -1,0 +1,3 @@
+# Derived Base Images
+
+These images derive directly from a base image defined in a parent directory.

--- a/base/derived/rust-latest/Dockerfile
+++ b/base/derived/rust-latest/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE_IMAGE=v0.1.0.buster
+FROM $BASE_IMAGE
+MAINTAINER gordon.hart2@gmail.com
+
+# run rustup installer for root and user, accepting defaults
+
+USER root
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+USER gordonhart
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/base/derived/rust-latest/build.sh
+++ b/base/derived/rust-latest/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eux
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+BASE_DIR="$REPO_ROOT/base"
+THIS_DIR="$BASE_DIR/derived/rust-latest"
+
+source "$BASE_DIR/definitions.sh"
+
+pushd $THIS_DIR
+
+for debrel in ${DEBIAN_RELEASES[@]}; do
+    BASE_IMAGE="$(get_base_image_tag "$debrel")"
+    THIS_IMAGE="$BASE_IMAGE.rust"
+    echo "Building image $THIS_IMAGE..."
+    docker build \
+        --tag "$THIS_IMAGE" \
+        --build-arg BASE_IMAGE="$BASE_IMAGE" \
+        .
+done
+
+popd
+
+echo "Done!"


### PR DESCRIPTION
This PR introduces changes extending the build process to build any derived images with `build.sh` scripts located within `./base/derived`. The initial implementation includes a `rust-latest` build that extends Debian base images by installing the latest Rust toolchain using [rustup](https://rustup.rs/) for both user and root.

