### PR TITLE
Parameterize images based on USER_NAME in definitions.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Containerization Utilities
 
-- `base`: interactive-ready base images derived from difffferent Debian
-  releases. Large and clunky for production use but comfortable for hacking and
+- `base`: interactive-ready base images derived from different Debian releases.
+  Large and clunky for production use but comfortable for hacking and
   exploration.
+    - e.g. `gordonhart/base:v0.1.0.buster`
+    - `rust`: the above with the latest toolchain from [rustup](https://rustup.rs/)
+        - e.g. `gordonhart/base:v0.1.0.buster.rust`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,14 @@
   Large and clunky for production use but comfortable for hacking and
   exploration.
     - e.g. `gordonhart/base:v0.1.0.buster`
-    - `rust`: the above with the latest toolchain from [rustup](https://rustup.rs/)
-        - e.g. `gordonhart/base:v0.1.0.buster.rust`
+- `rust`: the above with the latest toolchain from [rustup](https://rustup.rs/)
+    - e.g. `gordonhart/base:v0.1.0.buster.rust`
 
 ## Usage
+
+The default image name is `gordonhart/base` and will include a user `gordonhart`
+with UID/GID 1000 and home `/home/gordonhart`. The user name and image name can
+be changed by modifying `base/definitions.sh`.
 
 ```bash
 # initialize:
@@ -23,7 +27,3 @@ $ make push
 # all of the above:
 $ make all
 ```
-
-The default image name is `gordonhart/base` and will include a user `gordonhart`
-with UID/GID 1000 and home `/home/gordonhart`. The user name and image name can
-be changed by modifying `base/definitions.sh`.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ $ make push
 # all of the above:
 $ make all
 ```
+
+The default image name is `gordonhart/base` and will include a user `gordonhart`
+with UID/GID 1000 and home `/home/gordonhart`. The user name and image name can
+be changed by modifying `base/definitions.sh`.

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,12 +1,16 @@
 ARG DEBIAN_RELEASE=buster
 FROM debian:$DEBIAN_RELEASE
-MAINTAINER gordon.hart2@gmail.com
+
+ARG USER_NAME=gordonhart
+ARG MAINTAINER_EMAIL=gordon.hart2@gmail.com
+
+LABEL maintainer=$MAINTAINER_EMAIL
 
 # add default user/group/home directory
-RUN groupadd --gid 1000 gordonhart
-RUN useradd --gid 1000 --uid 1000 --create-home --shell /bin/bash gordonhart
-WORKDIR /home/gordonhart
-RUN chown -R gordonhart:gordonhart /home/gordonhart
+RUN groupadd --gid 1000 $USER_NAME
+RUN useradd --gid 1000 --uid 1000 --create-home --shell /bin/bash $USER_NAME
+WORKDIR /home/$USER_NAME
+RUN chown -R $USER_NAME:$USER_NAME /home/$USER_NAME
 
 # change root password to 'root', security is not very important for the
 # intended use case of these images
@@ -32,11 +36,11 @@ ADD dotfiles/.inputrc .inputrc
 ADD dotfiles/.pdbrc .pdbrc
 ADD dotfiles/.vimrc .vimrc
 
-USER gordonhart
-WORKDIR /home/gordonhart
-ADD --chown=gordonhart:gordonhart dotfiles/.bashrc .bashrc
-ADD --chown=gordonhart:gordonhart dotfiles/.inputrc .inputrc
-ADD --chown=gordonhart:gordonhart dotfiles/.pdbrc .pdbrc
-ADD --chown=gordonhart:gordonhart dotfiles/.vimrc .vimrc
+USER $USER_NAME
+WORKDIR /home/$USER_NAME
+ADD --chown=1000:1000 dotfiles/.bashrc .bashrc
+ADD --chown=1000:1000 dotfiles/.inputrc .inputrc
+ADD --chown=1000:1000 dotfiles/.pdbrc .pdbrc
+ADD --chown=1000:1000 dotfiles/.vimrc .vimrc
 
 CMD ["/bin/bash", "-l"]

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -8,8 +8,8 @@ RUN useradd --gid 1000 --uid 1000 --create-home --shell /bin/bash gordonhart
 WORKDIR /home/gordonhart
 RUN chown -R gordonhart:gordonhart /home/gordonhart
 
-# change root password to 'root', security is not important for an interactive
-# container on a trusted system
+# change root password to 'root', security is not very important for the
+# intended use case of these images
 RUN echo "root:root" | chpasswd
 
 ENV TERM xterm-256color

--- a/base/build.sh
+++ b/base/build.sh
@@ -15,6 +15,7 @@ for debrel in ${DEBIAN_RELEASES[@]}; do
     docker build \
         --tag "$THIS_IMAGE_TAG" \
         --build-arg DEBIAN_RELEASE="$debrel" \
+        --build-arg USER_NAME="$USER_NAME" \
         .
 done
 

--- a/base/definitions.sh
+++ b/base/definitions.sh
@@ -2,7 +2,9 @@
 
 set -eux
 
-BASE_IMAGE_NAME="gordonhart/base"
+USER_NAME="gordonhart"
+REPO_NAME="base"
+BASE_IMAGE_NAME="$USER_NAME/$REPO_NAME"
 BASE_IMAGE_VERSION="$(git describe --tags --always --dirty)"
 
 DEBIAN_RELEASES=(

--- a/base/derived/rust-latest/Dockerfile
+++ b/base/derived/rust-latest/Dockerfile
@@ -5,7 +5,11 @@ MAINTAINER gordon.hart2@gmail.com
 # run rustup installer for root and user, accepting defaults
 
 USER root
+WORKDIR /root
+ADD dotfiles/.cargo .cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 USER gordonhart
+WORKDIR /home/gordonhart
+ADD dotfiles/.cargo .cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/base/derived/rust-latest/Dockerfile
+++ b/base/derived/rust-latest/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE=v0.1.0.buster
 FROM $BASE_IMAGE
-MAINTAINER gordon.hart2@gmail.com
+
+ARG USER_NAME=gordonhart
 
 # run rustup installer for root and user, accepting defaults
 
@@ -9,7 +10,7 @@ WORKDIR /root
 ADD dotfiles/.cargo .cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-USER gordonhart
-WORKDIR /home/gordonhart
-ADD dotfiles/.cargo .cargo
+USER $USER_NAME
+WORKDIR /home/$USER_NAME
+ADD --chown=1000:1000 dotfiles/.cargo .cargo
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/base/derived/rust-latest/build.sh
+++ b/base/derived/rust-latest/build.sh
@@ -17,6 +17,7 @@ for debrel in ${DEBIAN_RELEASES[@]}; do
     docker build \
         --tag "$THIS_IMAGE" \
         --build-arg BASE_IMAGE="$BASE_IMAGE" \
+        --build-arg USER_NAME="$USER_NAME" \
         --file "$THIS_DIR/Dockerfile" \
         .
 done

--- a/base/derived/rust-latest/build.sh
+++ b/base/derived/rust-latest/build.sh
@@ -8,7 +8,7 @@ THIS_DIR="$BASE_DIR/derived/rust-latest"
 
 source "$BASE_DIR/definitions.sh"
 
-pushd $THIS_DIR
+pushd $BASE_DIR
 
 for debrel in ${DEBIAN_RELEASES[@]}; do
     BASE_IMAGE="$(get_base_image_tag "$debrel")"
@@ -17,6 +17,7 @@ for debrel in ${DEBIAN_RELEASES[@]}; do
     docker build \
         --tag "$THIS_IMAGE" \
         --build-arg BASE_IMAGE="$BASE_IMAGE" \
+        --file "$THIS_DIR/Dockerfile" \
         .
 done
 


### PR DESCRIPTION
This PR enables the adaptation of `gordonhart/base` images with user `gordonhart` (UID/GID 1000) and home `/home/gordonhart` to different users via a variable defined in `base/definitions.sh`. Changing this variable will change the main username in the images and the name of the images themselves via a `--build-arg`.